### PR TITLE
Fix for when POSTIDs are GUID's which can cause duplicates in WordPress

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -44,7 +44,7 @@ namespace BlogML.Helper
                     case ToolAction.ExportToWRX:
                         if (RequiredParametersPrintUsage(ToolAction.ExportToWRX, args))
                         {
-                            string wrxFileName = BlogMLToWRXConverter.GenerateWRXFile(setting.BlogMLFileName);
+                            string wrxFileName = BlogMLToWRXConverter.GenerateWRXFile(setting.BlogMLFileName, setting.BlogPostIdSeed);
                             Console.WriteLine("Created WRX format");
 
                             //Generate ReDirect, SourceQA and TargetQA File
@@ -149,7 +149,7 @@ namespace BlogML.Helper
 
         private static Setting ParseInput(string[] args)
         {
-            const string validArguments = "/Action: /BlogMLFile: /WRXFile: /QASourceFile: /QATargetFile: /QAReportFile: /SourceUrl: /TargetUrl: /NewWRXWithOnlyFailedPosts:";
+            const string validArguments = "/Action: /BlogMLFile: /WRXFile: /QASourceFile: /QATargetFile: /QAReportFile: /SourceUrl: /TargetUrl: /NewWRXWithOnlyFailedPosts: /BlogPostIdSeed:";
 
             Setting setting = new Setting();
             foreach (string s in args)
@@ -191,6 +191,17 @@ namespace BlogML.Helper
 
                 if (argumentKey == "/QAREPORTFILE")
                     setting.QAReportFileName = argumentValue;
+
+                if (argumentKey == "/BLOGPOSTIDSEED")
+                {
+                    int blogIdSeed = 0;
+                    setting.BlogPostIdSeed = 0;
+
+                    if (int.TryParse(argumentValue, out blogIdSeed))
+                    {
+                        setting.BlogPostIdSeed = blogIdSeed;
+                    }
+                }
             }
 
             return setting;
@@ -231,8 +242,8 @@ namespace BlogML.Helper
                     }
                     break;
                 case ToolAction.ExportToWRX:
-                    validArguments = "/Action: /BlogMLFile: /SourceUrl: /TargetUrl:";
-                    if (args.Length != 4)
+                    validArguments = "/Action: /BlogMLFile: /SourceUrl: /TargetUrl: /BlogPostIdSeed:";
+                    if (args.Length < 4)
                     {
                         Console.WriteLine("/BlogMLFile: /SourceUrl: /TargetUrl: are mandatory");
                         return false;
@@ -300,5 +311,12 @@ namespace BlogML.Helper
         public string SourceBaseUrl { get; set; }
         public string TargetBaseUrl { get; set; }
         public string QAReportFileName { get; set; }
+
+        /// <summary>
+        /// Allows you to change the BlogPost ID Seed
+        /// 
+        /// This helps when importing large amounts of posts into WordPress
+        /// </summary>
+        public int BlogPostIdSeed { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The code in this repository has error handling/logging enhancements and fixed im
 
 For detailed description see the blog post ["Migrating your blog from any BlogML based platform to WordPress"](http://blogs.biztalk360.com/migrating-your-blog-from-any-blogml-based-platform-to-wordpress-2/)
 
-###Extract from the post:
+### Extract from the post:
 
 Options available with the tool.  
   * RemoveComments  
@@ -21,9 +21,16 @@ You simply run the tool with the following command
 
 BlogML.Helper.exe /Action:ExportToWRX /BlogMLFile:BlogML.xml /SourceUrl:geekswithblogs.net/OldBlog /TargetUrl:NewBlog.wordpress.com
 
-###Similar tools :
+### Similar tools :
 To import blogML format to Wordpress, there are a few tools available.  
 If your new site is self hosted from Wordpress.org, you can install some of available plugins, e.g. [importing-a-big-honkin-blogml-xml-file-into-wordpress](http://nixmash.com/on-wordpress/importing-a-big-honkin-blogml-xml-file-into-wordpress/)
 But custom plugins not supported in Wordpress.com. For Wordpress.com you can use 
 [Blogmigrator](https://github.com/Dillie-O/blogmigrator ) or this tool(aka BlogML.Helper.exe).
 Blogmigrator has less steps to do, but doesn't import comments. If comments are important to you, the only choice that I found is this tool.
+
+## WordPress and high post ID's when using DasBlog as a Source
+Depending on which Blog Platform you are migrating from. The postid field is sometimes a GUID, this is usually the case with DasBlog. This can cause issues in the WordPress WRX Importer plugin. It tries to convert the GUIDs to integers but it does this in quite an odd way. If you have quite a few posts in the blog you are migrating it will eventually go past 2147483647 as a postid. This is fine in MySQL but not in WordPress where it attempts to convert postid's when you render posts in WordPress to an int. When PHP encounters a post id higher than 2147483647 when converting to int it just makes the post id 2147483647 and you will end up with what looks like multiple duplicates but what is happening is all blogposts with an id greater than 2147483647 will appear as the post that actually has that id in WordPress. 
+
+To get around this use the **BlogPostIdSeed**, first check what the highest postid is in your WordPress if you have existing posts. If you have a new site you should be good with a number around 50. This will replace all the postids in the generated files with an incremented number starting from the seed.
+
+BlogML.Helper.exe /Action:ExportToWRX /BlogMLFile:sourceblogML.xml /SourceUrl:myblog.com /TargetUrl:mynewblog.com /BlogPostIdSeed:50


### PR DESCRIPTION
I discovered when migrating from DasBlog that it uses GUID's for the POSTID. When WordPress imports the WRX file it attempts to convert these GUID's to integers. It does this in an unusual way which ends up with integers greater than **2147483647**. This is supported in MySQL but in WordPress when rendering a post it converts the POSTID to an integer. PHP when it encounters a number greater than **2147483647** will convert that number to **2147483647**. So when WordPress renders a post with an id of say **2147483650** it will end up rendering the post with an id of **2147483647** instead and it then appears your blog is filled with duplicates. 

To fix this I have added an optional parameter called **/BlogPostIdSeed** which allows you to add an identity seed the converter will increment and use instead of the original postid.